### PR TITLE
Anotação @ConditionalOnMissingBean na classe DefaultArchbaseSecurityConfiguration

### DIFF
--- a/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
+++ b/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
@@ -3,17 +3,15 @@ package br.com.archbase.security.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
-
-import java.util.List;
 
 public abstract class BaseArchbaseSecurityConfiguration implements ArchbaseSecurityConfigurator {
 

--- a/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
+++ b/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
@@ -30,10 +30,6 @@ public abstract class BaseArchbaseSecurityConfiguration implements ArchbaseSecur
                 .map(AntPathRequestMatcher::new)
                 .toArray(AntPathRequestMatcher[]::new);
 
-        if (getHttpDisableFrameOptions()) {
-            http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable));
-        }
-        
         http.csrf().disable()
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> {
@@ -79,6 +75,4 @@ public abstract class BaseArchbaseSecurityConfiguration implements ArchbaseSecur
     protected abstract void configureAuthorizationRules(HttpSecurity http) throws Exception;
 
     protected abstract ArchbaseJwtAuthenticationFilter getJwtAuthenticationFilter();
-
-    protected abstract boolean getHttpDisableFrameOptions();
 }

--- a/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
+++ b/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
@@ -75,4 +75,5 @@ public abstract class BaseArchbaseSecurityConfiguration implements ArchbaseSecur
     protected abstract void configureAuthorizationRules(HttpSecurity http) throws Exception;
 
     protected abstract ArchbaseJwtAuthenticationFilter getJwtAuthenticationFilter();
+
 }

--- a/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
+++ b/archbase-security/src/main/java/br/com/archbase/security/config/BaseArchbaseSecurityConfiguration.java
@@ -3,6 +3,7 @@ package br.com.archbase.security.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -29,6 +30,10 @@ public abstract class BaseArchbaseSecurityConfiguration implements ArchbaseSecur
                 .map(AntPathRequestMatcher::new)
                 .toArray(AntPathRequestMatcher[]::new);
 
+        if (getHttpDisableFrameOptions()) {
+            http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable));
+        }
+        
         http.csrf().disable()
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> {
@@ -74,4 +79,6 @@ public abstract class BaseArchbaseSecurityConfiguration implements ArchbaseSecur
     protected abstract void configureAuthorizationRules(HttpSecurity http) throws Exception;
 
     protected abstract ArchbaseJwtAuthenticationFilter getJwtAuthenticationFilter();
+
+    protected abstract boolean getHttpDisableFrameOptions();
 }

--- a/archbase-security/src/main/java/br/com/archbase/security/config/DefaultArchbaseSecurityConfiguration.java
+++ b/archbase-security/src/main/java/br/com/archbase/security/config/DefaultArchbaseSecurityConfiguration.java
@@ -123,4 +123,5 @@ public class DefaultArchbaseSecurityConfiguration extends BaseArchbaseSecurityCo
     protected CustomAccessDeniedHandler getAccessDeniedHandler() {
         return accessDeniedHandler;
     }
+
 }

--- a/archbase-security/src/main/java/br/com/archbase/security/config/DefaultArchbaseSecurityConfiguration.java
+++ b/archbase-security/src/main/java/br/com/archbase/security/config/DefaultArchbaseSecurityConfiguration.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -17,6 +18,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@ConditionalOnMissingBean(BaseArchbaseSecurityConfiguration.class)
 public class DefaultArchbaseSecurityConfiguration extends BaseArchbaseSecurityConfiguration {
 
     @Value("${archbase.security.whitelist}")
@@ -33,9 +35,6 @@ public class DefaultArchbaseSecurityConfiguration extends BaseArchbaseSecurityCo
 
     @Value("${archbase.security.cors.allow-credentials}")
     private boolean corsAllowCredentials;
-
-    @Value("${archbase.security.http.disable-frame-options}")
-    private boolean httpDisableFrameOptions;
 
     @Autowired
     private CustomAccessDeniedHandler accessDeniedHandler;
@@ -123,10 +122,5 @@ public class DefaultArchbaseSecurityConfiguration extends BaseArchbaseSecurityCo
     @Override
     protected CustomAccessDeniedHandler getAccessDeniedHandler() {
         return accessDeniedHandler;
-    }
-
-    @Override
-    protected boolean getHttpDisableFrameOptions() {
-        return httpDisableFrameOptions;
     }
 }

--- a/archbase-security/src/main/java/br/com/archbase/security/config/DefaultArchbaseSecurityConfiguration.java
+++ b/archbase-security/src/main/java/br/com/archbase/security/config/DefaultArchbaseSecurityConfiguration.java
@@ -34,6 +34,9 @@ public class DefaultArchbaseSecurityConfiguration extends BaseArchbaseSecurityCo
     @Value("${archbase.security.cors.allow-credentials}")
     private boolean corsAllowCredentials;
 
+    @Value("${archbase.security.http.disable-frame-options}")
+    private boolean httpDisableFrameOptions;
+
     @Autowired
     private CustomAccessDeniedHandler accessDeniedHandler;
 
@@ -122,4 +125,8 @@ public class DefaultArchbaseSecurityConfiguration extends BaseArchbaseSecurityCo
         return accessDeniedHandler;
     }
 
+    @Override
+    protected boolean getHttpDisableFrameOptions() {
+        return httpDisableFrameOptions;
+    }
 }


### PR DESCRIPTION
Anotação necessária para sobreescrever a classe de configuração de segurança.