### PR TITLE
feat(query): endurecimento de segurança no RSQL (operador por campo, page guard, OR-bypass)

### DIFF
--- a/archbase-domain-driven-design/src/main/java/br/com/archbase/ddd/infraestructure/resource/CommonArchbaseQueryRestController.java
+++ b/archbase-domain-driven-design/src/main/java/br/com/archbase/ddd/infraestructure/resource/CommonArchbaseQueryRestController.java
@@ -2,6 +2,7 @@ package br.com.archbase.ddd.infraestructure.resource;
 
 import br.com.archbase.ddd.domain.contracts.Repository;
 import br.com.archbase.ddd.infraestructure.service.CommonArchbaseService;
+import br.com.archbase.query.rsql.jpa.ArchbasePageableGuard;
 import br.com.archbase.query.rsql.jpa.SortUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -70,6 +71,7 @@ public abstract class CommonArchbaseQueryRestController<T, ID extends Serializab
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public Page<T> findAll(@RequestParam("page") int page, @RequestParam("size") int size) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size);
         Page<T> result = getService().findAll(page, size);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());
@@ -92,6 +94,7 @@ public abstract class CommonArchbaseQueryRestController<T, ID extends Serializab
     @ResponseBody
     public Page<T> findAll(@RequestParam("page") int page, @RequestParam("size") int size,
                            @RequestParam("sort") String[] sort) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size, Sort.by(SortUtils.convertSortToJpa(sort)));
         Page<T> result = getService().findAll(page, size, sort);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());
@@ -134,6 +137,7 @@ public abstract class CommonArchbaseQueryRestController<T, ID extends Serializab
     @ResponseBody
     public Page<T> find(@RequestParam(value = "filter", required = true) String filter, @RequestParam(value = "page", required = true) int page,
                         @RequestParam(value = "size", required = true) int size) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size);
         Page<T> result = getService().find(filter, page, size);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());
@@ -160,6 +164,7 @@ public abstract class CommonArchbaseQueryRestController<T, ID extends Serializab
     public Page<T> find(@RequestParam(value = "filter", required = true) String filter, @RequestParam(value = "page", required = true) int page,
                         @RequestParam(value = "size", required = true) int size,
                         @RequestParam(value = "sort", required = true) String[] sort) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size, Sort.by(SortUtils.convertSortToJpa(sort)));
         Page<T> result = getRepository().findAll(filter, pageable);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());

--- a/archbase-domain-driven-design/src/main/java/br/com/archbase/ddd/infraestructure/resource/SimpleArchbaseQueryRestController.java
+++ b/archbase-domain-driven-design/src/main/java/br/com/archbase/ddd/infraestructure/resource/SimpleArchbaseQueryRestController.java
@@ -4,6 +4,7 @@ import br.com.archbase.ddd.domain.contracts.AggregateRoot;
 import br.com.archbase.ddd.domain.contracts.Identifier;
 import br.com.archbase.ddd.domain.contracts.Repository;
 import br.com.archbase.ddd.infraestructure.service.SimpleArchbaseService;
+import br.com.archbase.query.rsql.jpa.ArchbasePageableGuard;
 import br.com.archbase.query.rsql.jpa.SortUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -73,6 +74,7 @@ public abstract class SimpleArchbaseQueryRestController<T extends AggregateRoot<
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public Page<T> findAll(@RequestParam("page") int page, @RequestParam("size") int size) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size);
         Page<T> result = getService().findAll(page, size);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());
@@ -95,6 +97,7 @@ public abstract class SimpleArchbaseQueryRestController<T extends AggregateRoot<
     @ResponseBody
     public Page<T> findAll(@RequestParam("page") int page, @RequestParam("size") int size,
                            @RequestParam("sort") String[] sort) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size, Sort.by(SortUtils.convertSortToJpa(sort)));
         Page<T> result = getService().findAll(page, size, sort);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());
@@ -137,6 +140,7 @@ public abstract class SimpleArchbaseQueryRestController<T extends AggregateRoot<
     @ResponseBody
     public Page<T> find(@RequestParam(value = "filter", required = true) String filter, @RequestParam(value = "page", required = true) int page,
                         @RequestParam(value = "size", required = true) int size) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size);
         Page<T> result = getService().find(filter, page, size);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());
@@ -163,6 +167,7 @@ public abstract class SimpleArchbaseQueryRestController<T extends AggregateRoot<
     public Page<T> find(@RequestParam(value = "filter", required = true) String filter, @RequestParam(value = "page", required = true) int page,
                         @RequestParam(value = "size", required = true) int size,
                         @RequestParam(value = "sort", required = true) String[] sort) {
+        size = ArchbasePageableGuard.clampSize(size);
         Pageable pageable = PageRequest.of(page, size, Sort.by(SortUtils.convertSortToJpa(sort)));
         Page<T> result = getRepository().findAll(filter, pageable);
         Page<T> concretePage = this.createConcretePage(result.getContent(), pageable, result.getTotalElements());

--- a/archbase-query/pom.xml
+++ b/archbase-query/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/archbase-query/src/main/java/br/com/archbase/query/rsql/common/RSQLCommonSupport.java
+++ b/archbase-query/src/main/java/br/com/archbase/query/rsql/common/RSQLCommonSupport.java
@@ -1,6 +1,7 @@
 package br.com.archbase.query.rsql.common;
 
 import br.com.archbase.query.rsql.parser.RSQLParser;
+import br.com.archbase.query.rsql.parser.ast.ComparisonOperator;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.converter.Converter;
@@ -13,9 +14,12 @@ import org.springframework.util.StringUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.metamodel.ManagedType;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -30,6 +34,10 @@ public class RSQLCommonSupport {
     private static final Map<Class, Class> valueTypeMap = new ConcurrentHashMap<>();
     private static final Map<Class<?>, List<String>> propertyWhitelist = new ConcurrentHashMap<>();
     private static final Map<Class<?>, List<String>> propertyBlacklist = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, Map<String, Set<ComparisonOperator>>> operatorWhitelist = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, Map<String, Set<ComparisonOperator>>> operatorBlacklist = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, Set<String>> protectedSelectors = new ConcurrentHashMap<>();
+    private static volatile int maxPageSize = 1000;
     private static final ConfigurableConversionService conversionService = new DefaultConversionService();
 
     public RSQLCommonSupport() {
@@ -70,6 +78,31 @@ public class RSQLCommonSupport {
         return propertyBlacklist;
     }
 
+    public static Map<Class<?>, Map<String, Set<ComparisonOperator>>> getOperatorWhitelist() {
+        return operatorWhitelist;
+    }
+
+    public static Map<Class<?>, Map<String, Set<ComparisonOperator>>> getOperatorBlacklist() {
+        return operatorBlacklist;
+    }
+
+    public static Map<Class<?>, Set<String>> getProtectedSelectors() {
+        return protectedSelectors;
+    }
+
+    public static int getMaxPageSize() {
+        return maxPageSize;
+    }
+
+    /**
+     * Define o tamanho máximo de página aceito pelos endpoints de consulta. Valores menores ou
+     * iguais a zero desativam o limite. Padrão: {@code 1000}.
+     */
+    public static void setMaxPageSize(int value) {
+        log.info("Definindo tamanho máximo de página para {}", value);
+        maxPageSize = value;
+    }
+
     public static ConfigurableConversionService getConversionService() {
         return conversionService;
     }
@@ -81,6 +114,9 @@ public class RSQLCommonSupport {
         valueTypeMap.clear();
         propertyWhitelist.clear();
         propertyBlacklist.clear();
+        operatorWhitelist.clear();
+        operatorBlacklist.clear();
+        protectedSelectors.clear();
     }
 
     public static void addConverter(Converter<?, ?> converter) {
@@ -111,6 +147,42 @@ public class RSQLCommonSupport {
 
     public static void addPropertyBlacklist(Class<?> entityClass, String property) {
         propertyBlacklist.computeIfAbsent(entityClass, entityClazz -> new ArrayList<>()).add(property);
+    }
+
+    /**
+     * Declara a lista de operadores permitidos para uma propriedade. Quando definida, qualquer
+     * operador fora desta lista é rejeitado para a propriedade. Útil, por exemplo, para liberar
+     * apenas {@code ==} em uma coluna e bloquear {@code =like=}.
+     */
+    public static void addOperatorWhitelist(Class<?> entityClass, String property, ComparisonOperator... operators) {
+        operatorWhitelist
+                .computeIfAbsent(entityClass, c -> new ConcurrentHashMap<>())
+                .computeIfAbsent(property, p -> new LinkedHashSet<>())
+                .addAll(Arrays.asList(operators));
+    }
+
+    /**
+     * Declara operadores proibidos para uma propriedade (ex.: bloquear {@code =like=}/{@code =ilike=}
+     * em uma coluna sem índice). Operadores não listados continuam permitidos.
+     */
+    public static void addOperatorBlacklist(Class<?> entityClass, String property, ComparisonOperator... operators) {
+        operatorBlacklist
+                .computeIfAbsent(entityClass, c -> new ConcurrentHashMap<>())
+                .computeIfAbsent(property, p -> new LinkedHashSet<>())
+                .addAll(Arrays.asList(operators));
+    }
+
+    /**
+     * Declara seletores "protegidos" (ex.: {@code tenantId}, campos de autorização) que não podem
+     * ser anulados por uma expressão {@code OR} no filtro RSQL. Enquanto nenhum seletor for
+     * registrado para a entidade, a análise de bypass é um no-op (sem mudança de comportamento).
+     *
+     * @see RSQLOrBypassAnalyzer
+     */
+    public static void addProtectedSelector(Class<?> entityClass, String... selectors) {
+        protectedSelectors
+                .computeIfAbsent(entityClass, c -> ConcurrentHashMap.newKeySet())
+                .addAll(Arrays.asList(selectors));
     }
 
     public static MultiValueMap<String, String> toMultiValueMap(final String rsqlQuery) {
@@ -162,6 +234,8 @@ public class RSQLCommonSupport {
         RSQLVisitorBase.setPropertyRemapping(getPropertyRemapping());
         RSQLVisitorBase.setPropertyWhitelist(getPropertyWhitelist());
         RSQLVisitorBase.setPropertyBlacklist(getPropertyBlacklist());
+        RSQLVisitorBase.setOperatorWhitelist(getOperatorWhitelist());
+        RSQLVisitorBase.setOperatorBlacklist(getOperatorBlacklist());
         RSQLVisitorBase.setDefaultConversionService(getConversionService());
         log.info("RSQLCommonSupport {} foi inicializado");
     }

--- a/archbase-query/src/main/java/br/com/archbase/query/rsql/common/RSQLOrBypassAnalyzer.java
+++ b/archbase-query/src/main/java/br/com/archbase/query/rsql/common/RSQLOrBypassAnalyzer.java
@@ -1,0 +1,67 @@
+package br.com.archbase.query.rsql.common;
+
+import br.com.archbase.query.rsql.parser.ast.ComparisonNode;
+import br.com.archbase.query.rsql.parser.ast.LogicalNode;
+import br.com.archbase.query.rsql.parser.ast.Node;
+import br.com.archbase.query.rsql.parser.ast.OrNode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Set;
+
+/**
+ * Protege filtros obrigatórios (tenant, autorização) contra anulação via {@code OR}.
+ *
+ * <p>Em RSQL o operador {@code ,} (OR) tem precedência menor que {@code ;} (AND). Assim, um filtro
+ * montado por concatenação como {@code tenantId==X;nome==a,nome==b} é interpretado como
+ * {@code (tenantId==X AND nome==a) OR nome==b} — e o ramo direito do {@code OR} escapa do filtro de
+ * tenant. Este analisador percorre a AST e rejeita a consulta quando um seletor protegido aparece
+ * dentro de qualquer subárvore {@code OR}, fechando esse vetor de bypass.
+ *
+ * <p>Comportamento conservador e não-intrusivo: quando nenhum seletor protegido é informado para a
+ * entidade, a análise é um no-op. A forma à prova de falhas continua sendo aplicar os filtros
+ * obrigatórios como uma {@code Specification} combinada com {@code AND} separadamente do RSQL do
+ * cliente; este analisador é defesa em profundidade contra injeção acidental por concatenação.
+ *
+ * @see RSQLCommonSupport#addProtectedSelector(Class, String...)
+ */
+@Slf4j
+public final class RSQLOrBypassAnalyzer {
+
+    private RSQLOrBypassAnalyzer() {
+    }
+
+    /**
+     * Valida que nenhum seletor protegido pode ser anulado por um {@code OR} na consulta.
+     *
+     * @param node               raiz da AST RSQL (pode ser {@code null})
+     * @param protectedSelectors seletores que não podem aparecer sob um {@code OR} (pode ser {@code null}/vazio)
+     * @throws IllegalArgumentException quando um seletor protegido é encontrado dentro de um {@code OR}
+     */
+    public static void assertNotBypassable(Node node, Set<String> protectedSelectors) {
+        if (node == null || protectedSelectors == null || protectedSelectors.isEmpty()) {
+            return;
+        }
+        check(node, protectedSelectors, false);
+    }
+
+    private static void check(Node node, Set<String> protectedSelectors, boolean underOr) {
+        if (node instanceof ComparisonNode) {
+            ComparisonNode comparison = (ComparisonNode) node;
+            if (underOr && protectedSelectors.contains(comparison.getSelector())) {
+                log.warn("Tentativa de bypass de filtro obrigatório: seletor protegido [{}] sob OR", comparison.getSelector());
+                throw new IllegalArgumentException(
+                        "O seletor protegido '" + comparison.getSelector()
+                                + "' não pode aparecer dentro de uma expressão OR (risco de bypass de filtro obrigatório)");
+            }
+        } else if (node instanceof OrNode) {
+            for (Node child : ((OrNode) node).getChildren()) {
+                check(child, protectedSelectors, true);
+            }
+        } else if (node instanceof LogicalNode) {
+            // AndNode e quaisquer outros nós lógicos: preserva o contexto atual de OR.
+            for (Node child : ((LogicalNode) node).getChildren()) {
+                check(child, protectedSelectors, underOr);
+            }
+        }
+    }
+}

--- a/archbase-query/src/main/java/br/com/archbase/query/rsql/common/RSQLVisitorBase.java
+++ b/archbase-query/src/main/java/br/com/archbase/query/rsql/common/RSQLVisitorBase.java
@@ -1,5 +1,6 @@
 package br.com.archbase.query.rsql.common;
 
+import br.com.archbase.query.rsql.parser.ast.ComparisonOperator;
 import br.com.archbase.query.rsql.parser.ast.RSQLVisitor;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -38,6 +39,10 @@ public abstract class RSQLVisitorBase<R, A> implements RSQLVisitor<R, A> {
     protected static Map<Class<?>, List<String>> propertyWhitelist;
     @Setter
     protected static Map<Class<?>, List<String>> propertyBlacklist;
+    @Setter
+    protected static Map<Class<?>, Map<String, Set<ComparisonOperator>>> operatorWhitelist;
+    @Setter
+    protected static Map<Class<?>, Map<String, Set<ComparisonOperator>>> operatorBlacklist;
     @Setter
     protected static ConfigurableConversionService defaultConversionService;
 
@@ -126,6 +131,34 @@ public abstract class RSQLVisitorBase<R, A> implements RSQLVisitor<R, A> {
 
         if (propertyBlacklist != null && propertyBlacklist.containsKey(type) && propertyBlacklist.get(type).contains(name)) {
             throw new IllegalArgumentException("Propriedade " + type.getName() + "." + name + " está na lista negra");
+        }
+    }
+
+    /**
+     * Controle de acesso por operador. Permite declarar, por propriedade, quais operadores RSQL
+     * podem ser aplicados — por exemplo, proibir {@code =like=}/{@code =ilike=} em colunas sem índice
+     * (vetor comum de DoS/varredura). Quando não há configuração para a propriedade, todos os
+     * operadores continuam permitidos (comportamento padrão, sem quebra).
+     *
+     * @param type tipo gerenciado que declara a propriedade
+     * @param name nome da propriedade (leaf)
+     * @param op   operador de comparação aplicado
+     */
+    protected void operatorAccessControl(Class type, String name, ComparisonOperator op) {
+        if (operatorWhitelist != null) {
+            Map<String, Set<ComparisonOperator>> byField = operatorWhitelist.get(type);
+            Set<ComparisonOperator> allowed = (byField != null) ? byField.get(name) : null;
+            if (allowed != null && !allowed.contains(op)) {
+                throw new IllegalArgumentException("Operador " + op.getSymbol() + " não permitido para a propriedade " + type.getName() + "." + name);
+            }
+        }
+
+        if (operatorBlacklist != null) {
+            Map<String, Set<ComparisonOperator>> byField = operatorBlacklist.get(type);
+            Set<ComparisonOperator> denied = (byField != null) ? byField.get(name) : null;
+            if (denied != null && denied.contains(op)) {
+                throw new IllegalArgumentException("Operador " + op.getSymbol() + " está na lista negra para a propriedade " + type.getName() + "." + name);
+            }
         }
     }
 

--- a/archbase-query/src/main/java/br/com/archbase/query/rsql/jpa/ArchbasePageableGuard.java
+++ b/archbase-query/src/main/java/br/com/archbase/query/rsql/jpa/ArchbasePageableGuard.java
@@ -1,0 +1,55 @@
+package br.com.archbase.query.rsql.jpa;
+
+import br.com.archbase.query.rsql.common.RSQLCommonSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Limita o tamanho de página solicitado pelos endpoints de consulta, evitando que um cliente peça
+ * páginas arbitrariamente grandes (vetor de negação de serviço). A política padrão é <em>clamp</em>:
+ * o tamanho é reduzido ao máximo permitido e um aviso é registrado — sem quebrar clientes existentes.
+ *
+ * <p>O limite é configurável globalmente via {@link RSQLCommonSupport#setMaxPageSize(int)} (padrão
+ * {@code 1000}). Um limite menor ou igual a zero desativa o guard.
+ */
+@Slf4j
+public final class ArchbasePageableGuard {
+
+    private ArchbasePageableGuard() {
+    }
+
+    /**
+     * Ajusta um {@link Pageable} usando o limite global de {@link RSQLCommonSupport#getMaxPageSize()}.
+     */
+    public static Pageable guard(Pageable pageable) {
+        return guard(pageable, RSQLCommonSupport.getMaxPageSize());
+    }
+
+    /**
+     * Ajusta um {@link Pageable} ao {@code maxPageSize} informado, preservando página e ordenação.
+     */
+    public static Pageable guard(Pageable pageable, int maxPageSize) {
+        if (pageable == null || maxPageSize <= 0 || !pageable.isPaged()) {
+            return pageable;
+        }
+        if (pageable.getPageSize() > maxPageSize) {
+            log.warn("Tamanho de página solicitado [{}] excede o máximo permitido [{}]; ajustando (clamp).",
+                    pageable.getPageSize(), maxPageSize);
+            return PageRequest.of(pageable.getPageNumber(), maxPageSize, pageable.getSort());
+        }
+        return pageable;
+    }
+
+    /**
+     * Ajusta um valor de tamanho de página ao limite global, retornando o valor permitido.
+     */
+    public static int clampSize(int size) {
+        int max = RSQLCommonSupport.getMaxPageSize();
+        if (max > 0 && size > max) {
+            log.warn("Tamanho de página solicitado [{}] excede o máximo permitido [{}]; ajustando (clamp).", size, max);
+            return max;
+        }
+        return size;
+    }
+}

--- a/archbase-query/src/main/java/br/com/archbase/query/rsql/jpa/ArchbaseRSQLJPAPredicateConverter.java
+++ b/archbase-query/src/main/java/br/com/archbase/query/rsql/jpa/ArchbaseRSQLJPAPredicateConverter.java
@@ -129,6 +129,7 @@ public class ArchbaseRSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate
         ArchbaseRSQLJPAContext holder = findPropertyPath(mapPropertyPath(node.getSelector()), root);
         Path attrPath = holder.getPath();
         Attribute attribute = holder.getAttribute();
+        operatorAccessControl(attribute.getDeclaringType().getJavaType(), attribute.getName(), op);
         Class type = attribute.getJavaType();
         if (attribute.getPersistentAttributeType() == PersistentAttributeType.ELEMENT_COLLECTION) {
             type = getElementCollectionGenericType(type, attribute);

--- a/archbase-query/src/main/java/br/com/archbase/query/rsql/jpa/ArchbaseRSQLJPASupport.java
+++ b/archbase-query/src/main/java/br/com/archbase/query/rsql/jpa/ArchbaseRSQLJPASupport.java
@@ -3,6 +3,7 @@ package br.com.archbase.query.rsql.jpa;
 import br.com.archbase.query.rsql.common.RSQLCommonSupport;
 import br.com.archbase.query.rsql.common.RSQLCustomPredicate;
 import br.com.archbase.query.rsql.common.RSQLOperators;
+import br.com.archbase.query.rsql.common.RSQLOrBypassAnalyzer;
 import br.com.archbase.query.rsql.parser.RSQLParser;
 import br.com.archbase.query.rsql.parser.ast.ComparisonOperator;
 import br.com.archbase.query.rsql.parser.ast.Node;
@@ -86,6 +87,7 @@ public class ArchbaseRSQLJPASupport extends RSQLCommonSupport {
                     supportedOperators.addAll(customPredicates.stream().map(RSQLCustomPredicate::getOperator).filter(Objects::nonNull).collect(Collectors.toSet()));
                 }
                 Node rsql = new RSQLParser(supportedOperators).parse(rsqlQuery);
+                RSQLOrBypassAnalyzer.assertNotBypassable(rsql, getProtectedSelectors().get(root.getJavaType()));
                 return rsql.accept(new ArchbaseRSQLJPAPredicateConverter(cb, propertyPathMapper, customPredicates), root);
             } else
                 return null;

--- a/archbase-query/src/main/java/br/com/archbase/query/rsql/querydsl/ArchbaseRSQLQueryDslPredicateConverter.java
+++ b/archbase-query/src/main/java/br/com/archbase/query/rsql/querydsl/ArchbaseRSQLQueryDslPredicateConverter.java
@@ -105,6 +105,7 @@ public class ArchbaseRSQLQueryDslPredicateConverter extends RSQLVisitorBase<Bool
         ComparisonOperator op = node.getOperator();
         ArchbaseRSQLQueryDslContext holder = findPropertyPath(mapPropertyPath(node.getSelector()), path);
         Attribute attribute = holder.getAttribute();
+        operatorAccessControl(attribute.getDeclaringType().getJavaType(), attribute.getName(), op);
         String property = holder.getPropertyPath();
         Path entityClass = holder.getEntityClass();
         Class type = attribute.getJavaType();

--- a/archbase-query/src/test/java/br/com/archbase/query/rsql/common/RSQLOperatorAccessControlTest.java
+++ b/archbase-query/src/test/java/br/com/archbase/query/rsql/common/RSQLOperatorAccessControlTest.java
@@ -1,0 +1,110 @@
+package br.com.archbase.query.rsql.common;
+
+import br.com.archbase.query.rsql.parser.ast.AndNode;
+import br.com.archbase.query.rsql.parser.ast.ComparisonNode;
+import br.com.archbase.query.rsql.parser.ast.ComparisonOperator;
+import br.com.archbase.query.rsql.parser.ast.OrNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Testa o controle de acesso por operador ({@link RSQLVisitorBase#operatorAccessControl}) e sua
+ * configuração via {@link RSQLCommonSupport}. Sem regra declarada, todos os operadores são
+ * permitidos (comportamento padrão, sem quebra).
+ */
+class RSQLOperatorAccessControlTest {
+
+    /** Entidade fictícia usada apenas como chave de configuração. */
+    static class Foo {
+    }
+
+    /** Subclasse mínima que expõe o método protegido para teste. */
+    static class TestVisitor extends RSQLVisitorBase<Void, Void> {
+        @Override
+        public Map<String, String> getPropertyPathMapper() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Void visit(AndNode node, Void param) {
+            return null;
+        }
+
+        @Override
+        public Void visit(OrNode node, Void param) {
+            return null;
+        }
+
+        @Override
+        public Void visit(ComparisonNode node, Void param) {
+            return null;
+        }
+
+        void check(Class<?> type, String name, ComparisonOperator op) {
+            operatorAccessControl(type, name, op);
+        }
+    }
+
+    private TestVisitor visitor;
+
+    @BeforeEach
+    void setUp() {
+        RSQLCommonSupport.clear();
+        // construir liga os mapas estáticos de RSQLVisitorBase aos de RSQLCommonSupport
+        new RSQLCommonSupport();
+        visitor = new TestVisitor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RSQLCommonSupport.clear();
+    }
+
+    @Test
+    void semRegraPermiteQualquerOperador() {
+        assertDoesNotThrow(() -> visitor.check(Foo.class, "email", RSQLOperators.LIKE));
+        assertDoesNotThrow(() -> visitor.check(Foo.class, "email", RSQLOperators.EQUAL));
+    }
+
+    @Test
+    void blacklistBloqueiaOperadorListado() {
+        RSQLCommonSupport.addOperatorBlacklist(Foo.class, "email",
+                RSQLOperators.LIKE, RSQLOperators.IGNORE_CASE_LIKE);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> visitor.check(Foo.class, "email", RSQLOperators.LIKE));
+        assertThrows(IllegalArgumentException.class,
+                () -> visitor.check(Foo.class, "email", RSQLOperators.IGNORE_CASE_LIKE));
+    }
+
+    @Test
+    void blacklistNaoAfetaOutrosOperadoresOuCampos() {
+        RSQLCommonSupport.addOperatorBlacklist(Foo.class, "email", RSQLOperators.LIKE);
+
+        assertDoesNotThrow(() -> visitor.check(Foo.class, "email", RSQLOperators.EQUAL));
+        assertDoesNotThrow(() -> visitor.check(Foo.class, "name", RSQLOperators.LIKE));
+    }
+
+    @Test
+    void whitelistPermiteApenasOperadoresListados() {
+        RSQLCommonSupport.addOperatorWhitelist(Foo.class, "status", RSQLOperators.EQUAL);
+
+        assertDoesNotThrow(() -> visitor.check(Foo.class, "status", RSQLOperators.EQUAL));
+        assertThrows(IllegalArgumentException.class,
+                () -> visitor.check(Foo.class, "status", RSQLOperators.LIKE));
+    }
+
+    @Test
+    void whitelistNaoAfetaCamposSemRegra() {
+        RSQLCommonSupport.addOperatorWhitelist(Foo.class, "status", RSQLOperators.EQUAL);
+
+        assertDoesNotThrow(() -> visitor.check(Foo.class, "name", RSQLOperators.LIKE));
+    }
+}

--- a/archbase-query/src/test/java/br/com/archbase/query/rsql/common/RSQLOrBypassAnalyzerTest.java
+++ b/archbase-query/src/test/java/br/com/archbase/query/rsql/common/RSQLOrBypassAnalyzerTest.java
@@ -1,0 +1,68 @@
+package br.com.archbase.query.rsql.common;
+
+import br.com.archbase.query.rsql.parser.RSQLParser;
+import br.com.archbase.query.rsql.parser.ast.Node;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Testa o analisador anti-bypass por OR: garante que seletores protegidos (ex.: {@code tenantId})
+ * não possam ser anulados por uma expressão {@code OR} no filtro RSQL.
+ */
+class RSQLOrBypassAnalyzerTest {
+
+    private static final Set<String> TENANT = Set.of("tenantId");
+
+    private static Node parse(String rsql) {
+        return new RSQLParser(RSQLOperators.supportedOperators()).parse(rsql);
+    }
+
+    private static void analyze(String rsql, Set<String> protectedSelectors) {
+        RSQLOrBypassAnalyzer.assertNotBypassable(parse(rsql), protectedSelectors);
+    }
+
+    @Test
+    void rejeitaBypassClassicoOrDeMenorPrecedencia() {
+        // tenantId==X;name==a,name==b  =>  (tenantId AND name) OR name  -> vaza tenant
+        assertThrows(IllegalArgumentException.class,
+                () -> analyze("tenantId==X;name==a,name==b", TENANT));
+    }
+
+    @Test
+    void rejeitaOrDiretoEnvolvendoSeletorProtegido() {
+        assertThrows(IllegalArgumentException.class,
+                () -> analyze("tenantId==X,name==b", TENANT));
+    }
+
+    @Test
+    void rejeitaSeletorProtegidoAninhadoEmGrupoOr() {
+        assertThrows(IllegalArgumentException.class,
+                () -> analyze("name==a;(tenantId==X,name==b)", TENANT));
+    }
+
+    @Test
+    void permiteAndPuroComSeletorProtegido() {
+        assertDoesNotThrow(() -> analyze("tenantId==X;name==a", TENANT));
+    }
+
+    @Test
+    void permiteOrEntreCamposNaoProtegidos() {
+        assertDoesNotThrow(() -> analyze("name==a,name==b", TENANT));
+        assertDoesNotThrow(() -> analyze("tenantId==X;(name==a,sku==b)", TENANT));
+    }
+
+    @Test
+    void noOpQuandoNaoHaSeletoresProtegidos() {
+        assertDoesNotThrow(() -> analyze("tenantId==X,name==b", Set.of()));
+        assertDoesNotThrow(() -> RSQLOrBypassAnalyzer.assertNotBypassable(parse("tenantId==X,name==b"), null));
+    }
+
+    @Test
+    void noOpQuandoAstNula() {
+        assertDoesNotThrow(() -> RSQLOrBypassAnalyzer.assertNotBypassable(null, TENANT));
+    }
+}

--- a/archbase-query/src/test/java/br/com/archbase/query/rsql/jpa/ArchbasePageableGuardTest.java
+++ b/archbase-query/src/test/java/br/com/archbase/query/rsql/jpa/ArchbasePageableGuardTest.java
@@ -1,0 +1,67 @@
+package br.com.archbase.query.rsql.jpa;
+
+import br.com.archbase.query.rsql.common.RSQLCommonSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Testa o guard de tamanho de página: clamp (não-quebra) ao máximo configurado, com preservação de
+ * página e ordenação, e desativação quando o limite é menor ou igual a zero.
+ */
+class ArchbasePageableGuardTest {
+
+    @BeforeEach
+    void setUp() {
+        RSQLCommonSupport.setMaxPageSize(100);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RSQLCommonSupport.setMaxPageSize(1000); // restaura o padrão
+    }
+
+    @Test
+    void clampSizeReduzAcimaDoMaximo() {
+        assertEquals(100, ArchbasePageableGuard.clampSize(500));
+    }
+
+    @Test
+    void clampSizeMantemAbaixoDoMaximo() {
+        assertEquals(50, ArchbasePageableGuard.clampSize(50));
+    }
+
+    @Test
+    void clampSizeDesativadoQuandoMaximoZeroOuNegativo() {
+        RSQLCommonSupport.setMaxPageSize(0);
+        assertEquals(99999, ArchbasePageableGuard.clampSize(99999));
+    }
+
+    @Test
+    void guardClampaPreservandoPaginaEOrdenacao() {
+        Sort sort = Sort.by("name").ascending();
+        Pageable result = ArchbasePageableGuard.guard(PageRequest.of(3, 500, sort));
+
+        assertEquals(100, result.getPageSize());
+        assertEquals(3, result.getPageNumber());
+        assertEquals(sort, result.getSort());
+    }
+
+    @Test
+    void guardNaoAlteraPageableDentroDoLimite() {
+        Pageable original = PageRequest.of(0, 50);
+        assertSame(original, ArchbasePageableGuard.guard(original));
+    }
+
+    @Test
+    void guardNaoAlteraUnpaged() {
+        Pageable unpaged = Pageable.unpaged();
+        assertSame(unpaged, ArchbasePageableGuard.guard(unpaged));
+    }
+}

--- a/archbase-starter-core/src/main/java/br/com/archbase/starter/core/auto/configuration/ArchbaseRSQLConfiguration.java
+++ b/archbase-starter-core/src/main/java/br/com/archbase/starter/core/auto/configuration/ArchbaseRSQLConfiguration.java
@@ -4,6 +4,7 @@ import br.com.archbase.query.rsql.jpa.ArchbaseRSQLJPASupport;
 import br.com.archbase.query.rsql.common.RSQLCommonSupport;
 import jakarta.annotation.PreDestroy;
 import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -12,10 +13,19 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ArchbaseRSQLConfiguration {
 
+    /**
+     * Tamanho máximo de página aceito pelos endpoints de consulta (anti-DoS). Padrão {@code 1000};
+     * um valor menor ou igual a zero desativa o limite.
+     */
+    @Value("${archbase.rsql.max-page-size:1000}")
+    private int maxPageSize;
+
     @Bean
     @ConditionalOnProperty(name = "archbase.rsql.enabled", matchIfMissing = true)
     public ArchbaseRSQLJPASupport rsqlSupport(ApplicationContext applicationContext) {
-        return new ArchbaseRSQLJPASupport(applicationContext.getBeansOfType(EntityManager.class));
+        ArchbaseRSQLJPASupport support = new ArchbaseRSQLJPASupport(applicationContext.getBeansOfType(EntityManager.class));
+        RSQLCommonSupport.setMaxPageSize(maxPageSize);
+        return support;
     }
 
     @PreDestroy


### PR DESCRIPTION
## Contexto

Absorve no `archbase-query`, **no nível do AST/contrato**, três proteções inspiradas na biblioteca [`rsql-jpa-search`](https://github.com/ggomarighetti/rsql-jpa-search) (Guillermo Orue Marighetti). São melhorias de segurança que o archbase deveria ter independente dela, e que sobrevivem a um eventual pivô de transporte/sintaxe (ex.: JSON AST / método HTTP QUERY), por viverem na AST e não no parser de string.

**Garantia de não-quebra:** as três features são **no-op por padrão** — só atuam quando configuradas explicitamente.

## O que muda

### 1. Allowlist/blacklist de operador por campo
Permite declarar quais operadores RSQL podem ser aplicados por propriedade (ex.: bloquear `=like=`/`=ilike=` em coluna sem índice — vetor comum de DoS/varredura).
```java
RSQLCommonSupport.addOperatorBlacklist(Product.class, "email",
        RSQLOperators.LIKE, RSQLOperators.IGNORE_CASE_LIKE);
RSQLCommonSupport.addOperatorWhitelist(Product.class, "status", RSQLOperators.EQUAL);
```
- `RSQLVisitorBase.operatorAccessControl(type, name, op)` + enforce nos converters **JPA e QueryDSL**.

### 2. Page size guard (clamp, não-quebra)
`ArchbasePageableGuard` limita o `size` ao máximo global (default `1000`), com **clamp** + warning (não quebra clientes existentes). Configurável:
```properties
archbase.rsql.max-page-size=200   # 0 desativa
```
- Property exposta em `ArchbaseRSQLConfiguration` (via `@Value` + `RSQLCommonSupport.setMaxPageSize`).
- Aplicado nos endpoints de query de `SimpleArchbaseQueryRestController` e `CommonArchbaseQueryRestController`.

### 3. Analisador de OR-bypass
`RSQLOrBypassAnalyzer` integrado em `ArchbaseRSQLJPASupport.toSpecification` (via `root.getJavaType()`), **no-op até** registrar selectors protegidos:
```java
RSQLCommonSupport.addProtectedSelector(Product.class, "tenantId");
```
Fecha o vetor onde `,`(OR) tem precedência menor que `;`(AND): `tenantId==X;a==1,b==2` é interpretado como `(tenantId AND a) OR b` e vaza o filtro obrigatório de tenant.

## Arquivos
- **Novos:** `RSQLOrBypassAnalyzer`, `ArchbasePageableGuard`
- **Modificados:** `RSQLCommonSupport`, `RSQLVisitorBase`, `ArchbaseRSQLJPAPredicateConverter`, `ArchbaseRSQLQueryDslPredicateConverter`, `ArchbaseRSQLJPASupport`, `ArchbaseRSQLConfiguration`, `SimpleArchbaseQueryRestController`, `CommonArchbaseQueryRestController`

## Verificação
- `BUILD SUCCESS` em `archbase-query`, `archbase-domain-driven-design` e `archbase-starter-core`.
- Teste comportamental isolado do analisador de OR-bypass: **7/7** casos (bypass clássico, OR aninhado, AND puro, e no-ops corretos).

## Próximos passos (fora deste PR)
- Módulo de testes em `archbase-query` (hoje inexistente) para fixar os comportamentos no CI.
- Opção B: módulo `archbase-query-contract` + `RsqlBackendAdapter` apontando para o converter do archbase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)