### PR TITLE
Release 3.0.1 — higiene Boot 4 p/ consumidores + archbase-query-contract

### DIFF
--- a/archbase-annotation-processor/pom.xml
+++ b/archbase-annotation-processor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-domain-driven-design-spec</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/archbase-architecture-rules/pom.xml
+++ b/archbase-architecture-rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-architecture/pom.xml
+++ b/archbase-architecture/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>br.com.archbase</groupId>
         <artifactId>archbase-app-framework</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>archbase-architecture</artifactId>

--- a/archbase-codegen-maven-plugin/pom.xml
+++ b/archbase-codegen-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <packaging>maven-plugin</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/archbase-domain-driven-design-spec/pom.xml
+++ b/archbase-domain-driven-design-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-domain-driven-design-spec/pom.xml
+++ b/archbase-domain-driven-design-spec/pom.xml
@@ -13,9 +13,11 @@
     <name>Archbase Domain Driven Design Specification</name>
 
     <dependencies>
+        <!-- Variante Jakarta (Spring Boot 4 / springdoc-jakarta). A não-Jakarta forçava o consumidor
+             a excluir swagger-annotations/core/models e readicionar swagger-annotations-jakarta. -->
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
             <version>2.2.50</version>
         </dependency>
         <dependency>

--- a/archbase-domain-driven-design/pom.xml
+++ b/archbase-domain-driven-design/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,19 +15,19 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-query</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-domain-driven-design-spec</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-error-handling</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/archbase-error-handling/pom.xml
+++ b/archbase-error-handling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-event-driven-spec/pom.xml
+++ b/archbase-event-driven-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-event-driven/pom.xml
+++ b/archbase-event-driven/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-event-driven-spec</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-domain-driven-design-spec</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/archbase-hypersistence/pom.xml
+++ b/archbase-hypersistence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.com.archbase</groupId>
         <artifactId>archbase-app-framework</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>archbase-hypersistence</artifactId>

--- a/archbase-logging/pom.xml
+++ b/archbase-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-mapper/pom.xml
+++ b/archbase-mapper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-modular-monolith/pom.xml
+++ b/archbase-modular-monolith/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.com.archbase</groupId>
         <artifactId>archbase-app-framework</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>archbase-modular-monolith</artifactId>

--- a/archbase-multitenancy/pom.xml
+++ b/archbase-multitenancy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,18 +22,18 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-shared-kernel</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-validation</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <artifactId>archbase-domain-driven-design</artifactId>
         </dependency>
         <dependency>

--- a/archbase-plugin-manager/pom.xml
+++ b/archbase-plugin-manager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-semver-implementation</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -115,7 +115,7 @@
                                 <path>
                                     <groupId>br.com.archbase</groupId>
                                     <artifactId>archbase-plugin-manager</artifactId>
-                                    <version>3.0.0</version>
+                                    <version>3.0.1</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>

--- a/archbase-query-contract/pom.xml
+++ b/archbase-query-contract/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-query</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.github.ggomarighetti</groupId>

--- a/archbase-query-contract/pom.xml
+++ b/archbase-query-contract/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>archbase-app-framework</artifactId>
+        <groupId>br.com.archbase</groupId>
+        <version>3.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>archbase-query-contract</artifactId>
+    <name>Archbase Query Contract</name>
+    <description>
+        Ponte opcional entre a camada de contrato/governança da biblioteca rsql-jpa-search
+        (io.github.ggomarighetti) e o motor RSQL do Archbase. Fornece um RsqlBackendAdapter que
+        compila a requisição validada para uma JPA Specification usando o ArchbaseRSQLJPASupport,
+        ganhando a governança (allowlist de campo/operador, validação, paging) sem trocar o motor.
+    </description>
+
+    <properties>
+        <rsql-jpa-search.version>2.0.0</rsql-jpa-search.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>br.com.archbase</groupId>
+            <artifactId>archbase-query</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.ggomarighetti</groupId>
+            <artifactId>rsql-jpa-search-core</artifactId>
+            <version>${rsql-jpa-search.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/archbase-query-contract/src/main/java/br/com/archbase/query/contract/ArchbaseRsqlBackendAdapter.java
+++ b/archbase-query-contract/src/main/java/br/com/archbase/query/contract/ArchbaseRsqlBackendAdapter.java
@@ -1,0 +1,37 @@
+package br.com.archbase.query.contract;
+
+import br.com.archbase.query.rsql.jpa.ArchbaseRSQLJPASupport;
+import io.github.ggomarighetti.rsqljpasearch.rsql.RsqlCompilationRequest;
+import io.github.ggomarighetti.rsqljpasearch.rsql.backend.RsqlBackendAdapter;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Map;
+
+/**
+ * Backend de RSQL ({@link RsqlBackendAdapter}) que delega a compilação ao motor do Archbase.
+ *
+ * <p>A biblioteca {@code rsql-jpa-search} (io.github.ggomarighetti) fornece a camada de
+ * contrato/governança — declaração de campos expostos, mapeamento selector→path, allowlist de
+ * operadores, validação de valores e paging — e abstrai o motor de tradução via este SPI. Este
+ * adapter conecta essa governança ao {@link ArchbaseRSQLJPASupport}, de modo que a
+ * {@link Specification} final é produzida pelo motor do Archbase (mantendo as proteções já
+ * existentes nele) em vez do backend padrão (perplexhub).
+ *
+ * <p>Como a requisição validada ({@link RsqlCompilationRequest}) carrega a string RSQL original e a
+ * definição, a ponte é direta: usa-se o mapa canônico selector público → caminho JPA exposto por
+ * {@code SearchDefinition.filteringPaths()} como {@code propertyPathMapper} e delega-se a
+ * {@link ArchbaseRSQLJPASupport#toSpecification(String, boolean, Map)}.
+ *
+ * <p><strong>Limitação:</strong> a string RSQL é reanalisada pelo parser do Archbase, então os
+ * operadores usados na definição devem pertencer ao conjunto suportado pelo Archbase
+ * ({@code br.com.archbase.query.rsql.common.RSQLOperators}). Operadores customizados registrados
+ * apenas na biblioteca de contrato não são reconhecidos por este backend.
+ */
+public final class ArchbaseRsqlBackendAdapter implements RsqlBackendAdapter {
+
+    @Override
+    public <T> Specification<T> compile(RsqlCompilationRequest<T> request) {
+        Map<String, String> propertyPathMapper = request.definition().filteringPaths();
+        return ArchbaseRSQLJPASupport.toSpecification(request.rsql(), request.distinct(), propertyPathMapper);
+    }
+}

--- a/archbase-query-contract/src/main/java/br/com/archbase/query/contract/ArchbaseRsqlContractAutoConfiguration.java
+++ b/archbase-query-contract/src/main/java/br/com/archbase/query/contract/ArchbaseRsqlContractAutoConfiguration.java
@@ -1,0 +1,30 @@
+package br.com.archbase.query.contract;
+
+import io.github.ggomarighetti.rsqljpasearch.rsql.backend.RsqlBackendAdapter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Registra o {@link ArchbaseRsqlBackendAdapter} como backend de RSQL da biblioteca de contrato.
+ *
+ * <p>É processada <em>antes</em> da auto-configuração de engine da {@code rsql-jpa-search} (cujo bean
+ * de backend é {@code @ConditionalOnMissingBean}), de modo que o adapter do Archbase passa a ser o
+ * backend efetivo, substituindo o padrão (perplexhub), sem que o usuário precise excluir nada.
+ *
+ * <p>Pode ser desligada com {@code archbase.query.contract.enabled=false}, e o usuário ainda pode
+ * fornecer o próprio bean {@link RsqlBackendAdapter} para sobrepor este.
+ */
+@AutoConfiguration(beforeName = "io.github.ggomarighetti.rsqljpasearch.autoconfigure.RsqlJpaSearchEngineAutoConfiguration")
+@ConditionalOnClass(RsqlBackendAdapter.class)
+@ConditionalOnProperty(prefix = "archbase.query.contract", name = "enabled", matchIfMissing = true)
+public class ArchbaseRsqlContractAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RsqlBackendAdapter archbaseRsqlBackendAdapter() {
+        return new ArchbaseRsqlBackendAdapter();
+    }
+}

--- a/archbase-query-contract/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/archbase-query-contract/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+br.com.archbase.query.contract.ArchbaseRsqlContractAutoConfiguration

--- a/archbase-query-contract/src/test/java/br/com/archbase/query/contract/ArchbaseRsqlBackendAdapterTest.java
+++ b/archbase-query-contract/src/test/java/br/com/archbase/query/contract/ArchbaseRsqlBackendAdapterTest.java
@@ -1,0 +1,157 @@
+package br.com.archbase.query.contract;
+
+import br.com.archbase.query.rsql.common.RSQLCommonSupport;
+import br.com.archbase.query.rsql.jpa.ArchbaseRSQLJPASupport;
+import io.github.ggomarighetti.rsqljpasearch.compile.CompiledSearch;
+import io.github.ggomarighetti.rsqljpasearch.compile.SearchCompiler;
+import io.github.ggomarighetti.rsqljpasearch.definition.SearchDefinition;
+import io.github.ggomarighetti.rsqljpasearch.policy.SearchPolicy;
+import io.github.ggomarighetti.rsqljpasearch.rsql.engine.SearchRsqlEngine;
+import io.github.ggomarighetti.rsqljpasearch.rsql.engine.SearchRsqlEngines;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Teste de integração ponta a ponta: a camada de contrato da {@code rsql-jpa-search} compila um
+ * filtro RSQL através do {@link ArchbaseRsqlBackendAdapter} (motor do Archbase) e executa contra um
+ * banco H2 real. Valida filtro por campo simples, por path mapeado (associação) e por operador de
+ * comparação. O JPA é inicializado manualmente (sem slices do Spring Boot) para autossuficiência.
+ */
+class ArchbaseRsqlBackendAdapterTest {
+
+    /** Contrato: expõe "name", "price" e "category" (mapeado para o path interno category.name). */
+    private static final SearchDefinition<Product> DEFINITION = SearchDefinition.builder()
+            .entity(Product.class)
+            .fields(fields -> {
+                fields.add("name", String.class, field -> field.filterable());
+                fields.add("category", String.class, field -> field.path("category.name").filterable());
+                fields.add("price", Integer.class, field -> field.filterable());
+            })
+            .build();
+
+    private static EntityManagerFactory entityManagerFactory;
+
+    private EntityManager entityManager;
+    private SearchCompiler compiler;
+
+    @BeforeAll
+    static void bootstrapJpa() {
+        entityManagerFactory = Persistence.createEntityManagerFactory("contractPU");
+    }
+
+    @AfterAll
+    static void shutdownJpa() {
+        if (entityManagerFactory != null) {
+            entityManagerFactory.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        entityManager = entityManagerFactory.createEntityManager();
+
+        // Liga o estado estático do motor do Archbase ao EntityManager (o que o
+        // ArchbaseRSQLConfiguration faz em runtime).
+        RSQLCommonSupport.clear();
+        new ArchbaseRSQLJPASupport(Map.of("default", entityManager));
+
+        SearchRsqlEngine engine = SearchRsqlEngines.builder(new ArchbaseRsqlBackendAdapter())
+                .conversionService(new DefaultConversionService())
+                .build();
+        // Política que permite consultas sem paginação, para focar o teste no filtro/adapter.
+        SearchPolicy policy = SearchPolicy.defaults().toBuilder()
+                .paging(paging -> paging
+                        .allowUnpaged(true)
+                        .defaultUnpagedSize(100)
+                        .maxUnpagedSize(1000))
+                .build();
+        compiler = new SearchCompiler(engine, policy);
+
+        entityManager.getTransaction().begin();
+        Category perifericos = new Category("Perifericos");
+        Category monitores = new Category("Monitores");
+        entityManager.persist(perifericos);
+        entityManager.persist(monitores);
+        entityManager.persist(new Product("Teclado", 200, perifericos));
+        entityManager.persist(new Product("Mouse", 100, perifericos));
+        entityManager.persist(new Product("Monitor 24", 900, monitores));
+        entityManager.getTransaction().commit();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (entityManager != null && entityManager.isOpen()) {
+            entityManager.getTransaction().begin();
+            entityManager.createQuery("delete from Product").executeUpdate();
+            entityManager.createQuery("delete from Category").executeUpdate();
+            entityManager.getTransaction().commit();
+            entityManager.close();
+        }
+    }
+
+    /** Compila o filtro pelo pipeline de contrato e executa o Specification resultante via Criteria. */
+    private List<Product> search(String filter) {
+        CompiledSearch<Product> compiled =
+                compiler.compile(filter, null, Pageable.unpaged(), DEFINITION);
+        return runQuery(compiled.specification());
+    }
+
+    private List<Product> runQuery(Specification<Product> specification) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Product> cq = cb.createQuery(Product.class);
+        Root<Product> root = cq.from(Product.class);
+        Predicate predicate = specification.toPredicate(root, cq, cb);
+        if (predicate != null) {
+            cq.where(predicate);
+        }
+        return entityManager.createQuery(cq).getResultList();
+    }
+
+    @Test
+    void filtraPorCampoSimples() {
+        assertThat(search("name==Teclado"))
+                .extracting(Product::getName)
+                .containsExactly("Teclado");
+    }
+
+    @Test
+    void filtraPorPathMapeadoDeAssociacao() {
+        // selector público "category" -> path interno "category.name"
+        assertThat(search("category==Perifericos"))
+                .extracting(Product::getName)
+                .containsExactlyInAnyOrder("Teclado", "Mouse");
+    }
+
+    @Test
+    void filtraComOperadorDeComparacao() {
+        assertThat(search("price=gt=150"))
+                .extracting(Product::getName)
+                .containsExactlyInAnyOrder("Teclado", "Monitor 24");
+    }
+
+    @Test
+    void filtraComExpressaoCompostaAndOr() {
+        // governança + motor: AND/OR compilados ponta a ponta
+        assertThat(search("category==Perifericos;price=lt=150"))
+                .extracting(Product::getName)
+                .containsExactly("Mouse");
+    }
+}

--- a/archbase-query-contract/src/test/java/br/com/archbase/query/contract/Category.java
+++ b/archbase-query-contract/src/test/java/br/com/archbase/query/contract/Category.java
@@ -1,0 +1,31 @@
+package br.com.archbase.query.contract;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    protected Category() {
+    }
+
+    public Category(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/archbase-query-contract/src/test/java/br/com/archbase/query/contract/Product.java
+++ b/archbase-query-contract/src/test/java/br/com/archbase/query/contract/Product.java
@@ -1,0 +1,47 @@
+package br.com.archbase.query.contract;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private int price;
+
+    @ManyToOne
+    private Category category;
+
+    protected Product() {
+    }
+
+    public Product(String name, int price, Category category) {
+        this.name = name;
+        this.price = price;
+        this.category = category;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+}

--- a/archbase-query-contract/src/test/resources/META-INF/persistence.xml
+++ b/archbase-query-contract/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+    <persistence-unit name="contractPU" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <class>br.com.archbase.query.contract.Product</class>
+        <class>br.com.archbase.query.contract.Category</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <validation-mode>NONE</validation-mode>
+        <properties>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:contract;DB_CLOSE_DELAY=-1"/>
+            <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="jakarta.persistence.jdbc.user" value="sa"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+            <property name="hibernate.show_sql" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/archbase-query/pom.xml
+++ b/archbase-query/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-resource-logger/pom.xml
+++ b/archbase-resource-logger/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-security/pom.xml
+++ b/archbase-security/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -64,23 +64,23 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-shared-kernel</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-validation</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <artifactId>archbase-domain-driven-design-spec</artifactId>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <artifactId>archbase-domain-driven-design</artifactId>
         </dependency>
         <dependency>

--- a/archbase-semver-implementation/pom.xml
+++ b/archbase-semver-implementation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-shared-kernel/pom.xml
+++ b/archbase-shared-kernel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <properties>
         <javaparser-core.version>3.28.1</javaparser-core.version>

--- a/archbase-starter-core/pom.xml
+++ b/archbase-starter-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>br.com.archbase</groupId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <artifactId>archbase-domain-driven-design</artifactId>
         </dependency>
         <dependency>
@@ -29,23 +29,23 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-multitenancy</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <artifactId>archbase-resource-logger</artifactId>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-domain-driven-design-spec</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-validation</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/archbase-starter-flyway/pom.xml
+++ b/archbase-starter-flyway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.com.archbase</groupId>
         <artifactId>archbase-app-framework</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>archbase-starter-flyway</artifactId>

--- a/archbase-starter-hypersistence/pom.xml
+++ b/archbase-starter-hypersistence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.com.archbase</groupId>
         <artifactId>archbase-app-framework</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>archbase-starter-hypersistence</artifactId>

--- a/archbase-starter-messaging/pom.xml
+++ b/archbase-starter-messaging/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>br.com.archbase</groupId>
         <artifactId>archbase-app-framework</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>archbase-starter-messaging</artifactId>

--- a/archbase-starter-multitenancy/pom.xml
+++ b/archbase-starter-multitenancy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-multitenancy</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 

--- a/archbase-starter-multitenancy/src/main/java/br/com/archbase/starter/multitenancy/auto/configuration/ArchbaseMultitenancyAutoConfiguration.java
+++ b/archbase-starter-multitenancy/src/main/java/br/com/archbase/starter/multitenancy/auto/configuration/ArchbaseMultitenancyAutoConfiguration.java
@@ -7,8 +7,10 @@ import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 import org.springframework.core.task.TaskDecorator;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -21,14 +23,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @ConditionalOnProperty(prefix = "archbase.multitenancy", name = "enabled", matchIfMissing = true)
 public class ArchbaseMultitenancyAutoConfiguration implements WebMvcConfigurer {
 
+    // ROLE_INFRASTRUCTURE: evita os WARN do BeanPostProcessorChecker no Spring Boot 4 quando
+    // estes beans de infra são injetados cedo (ex.: no meterRegistryPostProcessor).
     @Bean
     @ConditionalOnMissingBean(TaskDecorator.class)
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public TaskDecorator tenantAwareTaskDecorator() {
         return new ArchbaseTenantAwareTaskDecorator();
     }
 
     @Bean
     @ConditionalOnMissingBean(AsyncConfigurer.class)
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public AsyncConfig asyncConfig() {
         return new AsyncConfig();
     }

--- a/archbase-starter-security/pom.xml
+++ b/archbase-starter-security/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-security</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 

--- a/archbase-starter/pom.xml
+++ b/archbase-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,17 +16,17 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-starter-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-starter-security</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-starter-multitenancy</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 

--- a/archbase-test-utils/pom.xml
+++ b/archbase-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-transformation/pom.xml
+++ b/archbase-transformation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-domain-driven-design-spec</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/archbase-validation-ddd-model/pom.xml
+++ b/archbase-validation-ddd-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-domain-driven-design-spec</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/archbase-validation/pom.xml
+++ b/archbase-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>br.com.archbase</groupId>
             <artifactId>archbase-shared-kernel</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/archbase-value-objects/pom.xml
+++ b/archbase-value-objects/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/archbase-workflow-process/pom.xml
+++ b/archbase-workflow-process/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>archbase-app-framework</artifactId>
         <groupId>br.com.archbase</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>br.com.archbase</groupId>
     <artifactId>archbase-app-framework</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <name>archbase-app-framework</name>
     <description>Archbase Application Framework</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <module>archbase-validation</module>
         <module>archbase-domain-driven-design</module>
         <module>archbase-query</module>
+        <module>archbase-query-contract</module>
         <module>archbase-codegen-maven-plugin</module>
         <module>archbase-transformation</module>
         <module>archbase-validation-ddd-model</module>


### PR DESCRIPTION
## Resumo
Patch release **3.0.1** do archbase (primeira linha 3.0.x, Spring Boot 4.1 / Java 25). Reúne:

### 1. Higiene p/ consumidores Boot 4
Contornos que o **integrall** (1º consumidor do archbase 3.0.0) teve que fazer e que agora o framework resolve:
- **`archbase-domain-driven-design-spec`:** `swagger-annotations` → **`swagger-annotations-jakarta`**. A variante não-Jakarta conflita com springdoc-jakarta (Boot 4) e forçava o consumidor a excluir `swagger-annotations/core/models` e readicionar a `-jakarta`. _(Validado end-to-end: o boilerplate compila com `@Schema` sem declarar swagger.)_
- **`archbase-starter-multitenancy`:** `@Role(ROLE_INFRASTRUCTURE)` em `tenantAwareTaskDecorator` e `asyncConfig` — sem isso o Boot 4 emite WARN do `BeanPostProcessorChecker` (beans injetados cedo no `meterRegistryPostProcessor`).

### 2. `archbase-query-contract`
Módulo de ponte com rsql-jpa-search via `RsqlBackendAdapter` (opção B).

### 3. Release
Bump `3.0.0` → `3.0.1` em todos os módulos (`versions:set`) + na config de APT do `archbase-plugin-manager`.

## Verificação
`mvn clean install` verde em todos os módulos a 3.0.1 (Java 25 / Boot 4.1).

## Após o merge
Criar a tag **`3.0.1`** em `main` → dispara `publish-maven-central.yml` (publicação no Maven Central, irreversível).